### PR TITLE
Make the Mk3 test app work from the command-line with ts-node.

### DIFF
--- a/lib/components/input/packetized_pads.ts
+++ b/lib/components/input/packetized_pads.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from "events";
-import { Widget } from "./WIdget";
+import { Widget } from "./Widget";
 
 const PRESS_THRESHOLD = 256;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,18 @@
 {
-  "name": "node-traktor-f1",
-  "version": "0.0.1",
+  "name": "ni-controllers-lib",
+  "version": "1.0.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@types/node": {
       "version": "13.13.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g==",
-      "dev": true
+      "integrity": "sha512-3ySmiBYJPqgjiHA7oEaIo2Rzz0HrOZ7yrNO5HWyaE5q0lQ3BppDZ3N53Miz8bw2I7gh1/zir2MGVZBvpb1zq9g=="
     },
     "@types/node-hid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/node-hid/-/node-hid-1.2.0.tgz",
       "integrity": "sha512-OTum88c5BiabsVgixAmVqhUL4tm+OExYSqw6FxCNVUTTysB/evPP+CI34LhhGohS1YsYfdlXC7g4UHnduxWVlQ==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -22,14 +20,12 @@
     "@types/tinycolor2": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw==",
-      "dev": true
+      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
     },
     "@types/usb": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@types/usb/-/usb-1.5.1.tgz",
       "integrity": "sha512-1qhcYMLJ0I2HcRG3G/nBcRZ0KrrTdGdUNcCkEVgcga4KMlDXWh6LZJjVA6MiWEDa+BOaQTEfGJfuNaQ71IQOpg==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/tests/mk3_app.ts
+++ b/tests/mk3_app.ts
@@ -1,6 +1,6 @@
-const Mk3 = require('../lib/maschine_mk3');
+import { MaschineMk3 } from "../dist/maschine_mk3";
 
-const mk3 = new Mk3();
+const mk3 = new MaschineMk3();
 
 // ## Group Pads: Display colors with transient "flash" on press.
 for (let i = 1; i <= 8; i++) {


### PR DESCRIPTION
This contains a typo fix for "WIdget" from the previous merge and makes the mk3_app work from `ts-node`.  Going to quickly just self-merge this but going forward I'll try and stick to pull requests.