### PR TITLE
Add stepper support for Maschine Mk3

### DIFF
--- a/examples/maschine_mk3/runDemo.ts
+++ b/examples/maschine_mk3/runDemo.ts
@@ -40,6 +40,10 @@ export const runDemo = (mk3: MaschineMk3) =>
       mk3.on(`knobTouch${i}`, (touched) => {});
     }
 
+    mk3.on(`stepper:step`, ({ direction }) => {
+      console.log(`stepper: ${direction < 0 ? "decrement" : "increment"}`);
+    });
+
     for (let i = 1; i <= 2; i++) {
       mk3.on(`touchStrip${i}:changed`, ({ value, timestamp }) => {
         const hexTime = timestamp.toString(16).padStart(4, "0");

--- a/lib/maschine_mk3.ts
+++ b/lib/maschine_mk3.ts
@@ -6,6 +6,7 @@ interface MaschineMk3EventMap {
   "p:pressed": (index: number, pressure: number) => void;
   "p:pressure": (index: number, pressure: number) => void;
   "p:released": (index: number, pressure: 0) => void;
+  "stepper:step": (data: { direction: -1 | 1 }) => void;
 }
 
 export class MaschineMk3 extends BaseController {

--- a/lib/maschine_mk3_config.json
+++ b/lib/maschine_mk3_config.json
@@ -682,6 +682,12 @@
       }
     },
 
+    "steppers": {
+      "stepper": {
+        "addr": 11
+      }
+    },
+
     "knobs": {
       "k1": {
         "msb": 13,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ni-controllers-lib",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "A package providing access to some Native Instruments controllers. Supports all inputs and setting any LED and LCD displays when available.",
   "author": "Andrew Metcalf <met5678@gmail.com>",
   "files": [


### PR DESCRIPTION
#### What does this PR do?
Enable the stepper support for the Maschine MK3. In can be now observer like this:

```ts
 mk3.on(`stepper:step`, ({ direction }) => {
  // direction is either a negative number for anti-clockwise step
  // or positive for clockwise step
});
```

#### How should this be tested by the reviewer?
I added an event handler in the example app, so you can run it and check that the logged events are correct.
